### PR TITLE
Improve `execute_swaps`

### DIFF
--- a/game_controller.py
+++ b/game_controller.py
@@ -17,13 +17,17 @@ def start_new(gridle):
 
 
 def execute_swaps(gridle: Gridle, swaps: list[tuple[int, int]]):
+    shell = subprocess.Popen(["adb", "shell"], stdin=subprocess.PIPE)
     for start, end in swaps:
         start_coords = gridle.cells[start].get_centre()
         end_coords = gridle.cells[end].get_centre()
-        _adb_swipe(start_coords, end_coords)
+        _adb_swipe(shell, start_coords, end_coords)
+
+    shell.stdin.close()
+    shell.wait()
 
 
-def _adb_swipe(start, end, duration_ms=100):
+def _adb_swipe(shell, start, end, duration_ms=100):
     start_x, start_y = start
     end_x, end_y = end
-    subprocess.run(["adb", "shell", "input", "touchscreen", "swipe", str(start_x), str(start_y), str(end_x), str(end_y), str(duration_ms)])
+    shell.stdin.write(f"input touchscreen swipe {start_x} {start_y} {end_x} {end_y} {duration_ms}\n".encode())


### PR DESCRIPTION
This PR improves `execute_swaps` in `game_controller` by only creating one adb shell for the swaps.